### PR TITLE
Add validated function for retrieving validated data.

### DIFF
--- a/src/RequestAbstract.php
+++ b/src/RequestAbstract.php
@@ -131,4 +131,14 @@ abstract class RequestAbstract extends Request implements ValidatesWhenResolved
 
         return $this;
     }
+
+    /**
+     * Get the validated data from the request.
+     *
+     * @return array
+     */
+    public function validated()
+    {
+        return $this->getValidatorInstance()->validated();
+    }
 }


### PR DESCRIPTION
When requests are passed into a model directly, using the validated data is
useful to prevent any attempts at setting protected fields (e.g. a deleted field
that may not be intended to be set by the validated request).